### PR TITLE
Fix ID Number in 1xxxxxxxxxx Range

### DIFF
--- a/ThaiNationalIDGenerator.py
+++ b/ThaiNationalIDGenerator.py
@@ -11,7 +11,7 @@ Thai national ID number generator
 class ThaiNationalID_Generator:
     # Generate ID number randomly
     def generate_number(self):
-        random_num = random.randint(100000000000, 999999999999)
+        random_num = random.randint(100000000000, 199999999999)
         temp = random_num
         sumall = 0
 


### PR DESCRIPTION
I think that most of the latest thai id system are in range of 1xxxxxxxxxx